### PR TITLE
save babel-preset

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.5.1",
+    "babel-preset-es2015": "^6.5.0",
     "babel-register": "^6.5.2",
     "chai": "^3.5.0",
     "mocha": "^2.4.5",


### PR DESCRIPTION
Save babel-preset-es2015, since babel was relying on it.
