### PR TITLE
fix: exit errored process with a non-zero status

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -9,6 +9,7 @@ const runTask = task => {
 
   const stdoutStream = RxNode.fromReadableStream(stdout)
   const stderrStream = RxNode.fromReadableStream(stderr)
+    .select(e => process.stderr.write(e) && process.exit(1))
 
   return stdoutStream.merge(stderrStream)
 }
@@ -18,8 +19,7 @@ export const runTasks = tasks => {
   Observable.from(tasks)
     .selectMany(runTask)
     .subscribe(
-      output => process.stdout.write(output),
-      error => console.error('Task run error: ', error) && process.exit(1)
+      output => process.stdout.write(output)
     )
 }
 


### PR DESCRIPTION
When a process was erroring, that exit status wasn't being propagated correctly. By selecting on the stderr stream, we can exit the process properly.
